### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/robertxfreeman/aa9a71f9-1e1f-4719-abe7-c15caccfa242/ec9224a5-5587-4006-bba6-a32878769cf9/_apis/work/boardbadge/d1e01b78-9b54-470b-8f82-12b171aca84c)](https://dev.azure.com/robertxfreeman/aa9a71f9-1e1f-4719-abe7-c15caccfa242/_boards/board/t/ec9224a5-5587-4006-bba6-a32878769cf9/Microsoft.RequirementCategory)
 ![Code scanning - action](https://github.com/robertefreeman/hello-demo/workflows/Code%20scanning%20-%20action/badge.svg)
 
 ![](https://github.com/robertefreeman/hello-demo/workflows/Build%20and%20deploy/badge.svg)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/robertxfreeman/aa9a71f9-1e1f-4719-abe7-c15caccfa242/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.