### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/rofreema/0b1372c0-de4c-4d6a-903f-3d8a59de78b2/0e3ffbf8-a025-48a9-a69a-714283fc33bd/_apis/work/boardbadge/ab54eec7-1664-467a-874f-77f38011cbf3)](https://dev.azure.com/rofreema/0b1372c0-de4c-4d6a-903f-3d8a59de78b2/_boards/board/t/0e3ffbf8-a025-48a9-a69a-714283fc33bd/Microsoft.RequirementCategory)
 ![Code scanning - action](https://github.com/robertefreeman/hello-demo/workflows/Code%20scanning%20-%20action/badge.svg)
 
 ![](https://github.com/robertefreeman/hello-demo/workflows/Build%20and%20deploy/badge.svg)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/rofreema/0b1372c0-de4c-4d6a-903f-3d8a59de78b2/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.